### PR TITLE
murge with goal predictor

### DIFF
--- a/src/human_data_buffer/human_data_buffer/data_buffer.py
+++ b/src/human_data_buffer/human_data_buffer/data_buffer.py
@@ -20,6 +20,7 @@ class DataBufferNode(Node):
             10
         )
         # Publisher for the buffer data
+        # The buffer message contains lists of data for each agent
         self.pub_buffer = self.create_publisher(Buffer, 'buffer', 10)
         self.pub_timer = self.create_timer(0.5, self.publish_buffer)
 


### PR DESCRIPTION
The buffer will be used in the goal predictor node, so there will not be any velocity calculation or data reading from direct nodes of lidar senors and vision nodes  